### PR TITLE
fix/content_editor_cache_stale_type_version

### DIFF
--- a/Infrastructure/Content/Editor/ContentEditorCache.cs
+++ b/Infrastructure/Content/Editor/ContentEditorCache.cs
@@ -22,6 +22,8 @@ namespace Content.Editor
 
 		internal static event Action Cleared;
 
+		private static int _versionCounter;
+
 		private static Dictionary<string, ScriptableObject> cache
 		{
 			get
@@ -33,7 +35,10 @@ namespace Content.Editor
 			}
 		}
 
-		public static int version => cache.Count;
+		// Меняется на каждый ClearAndRefreshScrObjs, чтобы Drawer-ы и Refresh(Type) инвалидировались.
+		// Раньше было => cache.Count, но Count не меняется после пере-заполнения тем же набором ассетов,
+		// из-за чего _typeToVersion и кеш _found в Drawer-ах не перепроверялись.
+		public static int version => _versionCounter;
 
 		public static void ClearAndRefreshScrObjs()
 		{
@@ -41,6 +46,8 @@ namespace Content.Editor
 
 			_cache ??= new();
 			_cache.Clear();
+			_typeToVersion.Clear();
+			_versionCounter++;
 			foreach (var scriptableObject in AssetDatabaseUtility.GetAssets<ScriptableObject>())
 				Register(scriptableObject);
 		}

--- a/Infrastructure/Content/Editor/ContentEditorCache.cs
+++ b/Infrastructure/Content/Editor/ContentEditorCache.cs
@@ -22,7 +22,7 @@ namespace Content.Editor
 
 		internal static event Action Cleared;
 
-		private static int _versionCounter;
+		private static int _refreshCount;
 
 		private static Dictionary<string, ScriptableObject> cache
 		{
@@ -35,10 +35,7 @@ namespace Content.Editor
 			}
 		}
 
-		// Меняется на каждый ClearAndRefreshScrObjs, чтобы Drawer-ы и Refresh(Type) инвалидировались.
-		// Раньше было => cache.Count, но Count не меняется после пере-заполнения тем же набором ассетов,
-		// из-за чего _typeToVersion и кеш _found в Drawer-ах не перепроверялись.
-		public static int version => _versionCounter;
+		public static int version => cache.Count + _refreshCount;
 
 		public static void ClearAndRefreshScrObjs()
 		{
@@ -47,7 +44,7 @@ namespace Content.Editor
 			_cache ??= new();
 			_cache.Clear();
 			_typeToVersion.Clear();
-			_versionCounter++;
+			_refreshCount++;
 			foreach (var scriptableObject in AssetDatabaseUtility.GetAssets<ScriptableObject>())
 				Register(scriptableObject);
 		}

--- a/Infrastructure/Content/Editor/ContentEditorCache.cs
+++ b/Infrastructure/Content/Editor/ContentEditorCache.cs
@@ -24,6 +24,10 @@ namespace Content.Editor
 
 		private static int _refreshCount;
 
+		static ContentEditorCache() => Cleared += HandleCleared;
+
+		private static void HandleCleared() => _typeToVersion.Clear();
+
 		private static Dictionary<string, ScriptableObject> cache
 		{
 			get
@@ -43,7 +47,6 @@ namespace Content.Editor
 
 			_cache ??= new();
 			_cache.Clear();
-			_typeToVersion.Clear();
 			_refreshCount++;
 			foreach (var scriptableObject in AssetDatabaseUtility.GetAssets<ScriptableObject>())
 				Register(scriptableObject);


### PR DESCRIPTION
**Симптом**

В Инспекторе у `Portal-*_TeleportConfig` поля `Default Send/Receive Teleportation` периодически становятся красными. Без какой-либо ошибки, просто полностью красное поле, в нём пишется ID.

При этом:
- `TeleportationConfig` ассет лежит на диске.
- `_entry.guid` синхронизирован с Unity asset GUID (`NeedSync() == false`, `Validate() == true`, я скрипт написал проверить ассеты).
- Ассет зарегистрирован в `MiscDatabase.asset`.
- `ContentManager.Contains<TeleportationConfigData>(guid)` возвращает `true`.

Воспроизводилось странно: вчера у меня всё было ок после воспроизведения, у ГД ошибки. Сегодня попытался с нуля открытую юнити, поймал.

`Tools/Content/Database/Sync All` не помогает.

**Воспроизведение**

1. Открыть Unity без правок.
2. Сделать дубликат `14_TeleportationConfig.asset` через Ctrl+D, нажать Sync. Либо создать с нуля (у ГД были проблемы и в таком кейсе, но сам это не тестил).
3. Привязать клон в `Default Receive Teleportation` в `Portal-1_TeleportConfig`.
4. Нажать Play, выйти.
5. Ссылка остаётся красной.

**Что показал замер**

В битом состоянии, для одного и того же guid:
- `ContentManager.Contains<TeleportationConfigData>(guid)` = `true` (runtime resolver, заполнен через `PopulateAsync` во время Play).
- `ContentEditorCache.TryGetSource(typeof(TeleportationConfigData), guid)` = `false` (editor cache).

Inspector рисует ссылку через `ContentReferenceAttributeDrawer.FindSelectedSource`, а он лазит именно в `ContentEditorCache.TryGetSource`. Видит `false`, красит поле.

**Корень (возможно)**

В `Infrastructure/Content/Editor/ContentEditorCache.cs` сидят два бага вместе:

1. `_typeToVersion` не сбрасывается в `ClearAndRefreshScrObjs()`. Cleared event чистит `EditorContentEntryMap<T>._dictionary`, но `_typeToVersion[type]` остаётся со старым значением. Следующий `Refresh(type)` упирается в early-out (`currentVersion == version`) и карту не пересобирает. Карта пустая, `TryGetSource` всегда `false`.

2. `version => cache.Count` не менялся при перезаполнении тем же набором ассетов. `ContentReferenceAttributeDrawer` кеширует результат резолва в `_found = (key, source, contentVersion)` и пере-резолвит только если version поменялся. Раз `cache.Count` тот же, drawer держит закешированный `null` и в `TryGetSource` повторно не ходит. Даже ручной `Refresh(type, force: true)` не помогал, потому что drawer про это не знал.

**Фикс в `ClearAndRefreshScrObjs()`**

- Добавил `_typeToVersion.Clear()`, теперь `Refresh(type)` пересобирает карту для всех типов.
- `version` больше не считается через `cache.Count`. Вместо этого отдельный счётчик `_versionCounter`, инкремент при каждой пересборке. За счёт этого протухший `_found` во всех drawer'ах перестаёт совпадать по version и они идут резолвить заново.

**Тест**

Воспроизвёл через Ctrl+D + Play. До фикса `TryGetSource` = `false`, поле красное. После, `TryGetSource` = `true` для всех 4 ассетов (надублицировал для теста), поля зелёные сразу, без перезапуска Unity. Замер делал через одноразовый диагностический menu `Tools/Diagnose Teleport`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Улучшено поведение версионирования кеша редактора: повторное очищение и повторное заполнение кеша теперь всегда отмечается как изменение версии, даже если размер набора ассетов не меняется. Это обеспечивает корректное обновление отображения и надежную инвалидизацию данных в редакторе.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Winzardy/Fusumity/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->