### PR TITLE
bug/bug-321_marker_horizontal_distance

### DIFF
--- a/Infrastructure/UI/Widgets/Marker/UIMarker.cs
+++ b/Infrastructure/UI/Widgets/Marker/UIMarker.cs
@@ -173,6 +173,9 @@ namespace UI
 				{
 					var distance = worldPosition - position;
 
+					// Дистанцию меряем по горизонтали. Инстансы миров разнесены по Y (ViewRoot), вертикаль раздула бы её (BUG-321).
+					distance.y = 0f;
+
 					if (!distanceRange.Contains(distance))
 					{
 						DisableInternal();


### PR DESCRIPTION
Distance-гейт маркера считал дистанцию в 3D (Range<float>.Contains(Vector3) сравнивает sqrMagnitude). Инстансы миров разнесены друг от друга по вертикали через ViewRoot (worldInstancesVerticalDelta), поэтому на втором буфере мира этот сдвиг раздувал дистанцию, и distance-gated маркеры выпадали из диапазона.

Занулил Y дистанции перед проверкой, теперь считается только горизонталь.

Чинит BUG-321, из-за которого иконки над телепортами пропадали при повторном заходе на лвл. В top-down вертикаль на горизонтальную дистанцию влиять не должна, так что правка общая для marker-системы, а не хак под одну задачу.