### PR TITLE
[TASK-2989] [+] Added "Deferred gate"

### DIFF
--- a/Infrastructure/Analytics/AnalyticsManagement.cs
+++ b/Infrastructure/Analytics/AnalyticsManagement.cs
@@ -37,7 +37,7 @@ namespace Analytics
 
 			_cts = new CancellationTokenSource();
 
-			_deferred = new DeferredQueue<AnalyticsEventPayload>(SendInternal);
+			_deferred = new DeferredQueue<AnalyticsEventPayload>(SendDeferred);
 		}
 
 		public async UniTask InitializeAsync(CancellationToken cancellationToken)
@@ -96,20 +96,35 @@ namespace Analytics
 
 			if (_deferred.CanHandleNow())
 			{
-				SendInternal(payload);
+				SendInternal(in payload);
 				return;
 			}
 
-			// Параметры приходят из пула и вернутся туда сразу после вызова, поэтому копируем
-			_deferred.Enqueue(new AnalyticsEventPayload(payload.id)
+			// Параметры приходят из пула и вернутся туда сразу после вызова, поэтому копируем в свой словарь
+			if (payload.parameters != null)
 			{
-				parameters = payload.parameters != null
-					? new Dictionary<string, object>(payload.parameters)
-					: null
-			});
+				var parameters = DictionaryPool<string, object>.Get();
+				parameters.AddRange(payload.parameters);
+				payload.parameters = parameters;
+			}
+
+			_deferred.Enqueue(in payload);
 		}
 
-		private void SendInternal(AnalyticsEventPayload payload)
+		private void SendDeferred(in AnalyticsEventPayload payload)
+		{
+			try
+			{
+				SendInternal(in payload);
+			}
+			finally
+			{
+				if (payload.parameters != null)
+					DictionaryPool<string, object>.Release(payload.parameters);
+			}
+		}
+
+		private void SendInternal(in AnalyticsEventPayload payload)
 		{
 			foreach (var integration in _integrations)
 			{

--- a/Infrastructure/Analytics/AnalyticsManagement.cs
+++ b/Infrastructure/Analytics/AnalyticsManagement.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using Fusumity.Reactive;
 using JetBrains.Annotations;
 using Sapientia;
 using Sapientia.Collections;
@@ -23,6 +24,8 @@ namespace Analytics
 
 		private List<IAnalyticsIntegration> _integrations;
 
+		private DeferredQueue<AnalyticsEventPayload> _deferred;
+
 		public event Receiver<AnalyticsEventPayload> BeforeSend;
 
 		public bool Active => !_integrations.IsNullOrEmpty();
@@ -33,6 +36,8 @@ namespace Analytics
 			_isValidationEnabled = isValidationEnabled;
 
 			_cts = new CancellationTokenSource();
+
+			_deferred = new DeferredQueue<AnalyticsEventPayload>(SendInternal);
 		}
 
 		public async UniTask InitializeAsync(CancellationToken cancellationToken)
@@ -53,6 +58,8 @@ namespace Analytics
 		public void Dispose()
 		{
 			AsyncUtility.TriggerAndSetNull(ref _cts);
+
+			DisposeUtility.DisposeAndSetNull(ref _deferred);
 
 			if (_integrations.IsNullOrEmpty())
 				return;
@@ -84,6 +91,26 @@ namespace Analytics
 		{
 			BeforeSend?.Invoke(payload);
 
+			// Логируем до откладывания, пока в стеке виден отправитель
+			AnalyticsDebug.Log($"Sent event: {payload}\n{_cachedIntegrationsDebugMessage}");
+
+			if (_deferred.CanHandleNow())
+			{
+				SendInternal(payload);
+				return;
+			}
+
+			// Параметры приходят из пула и вернутся туда сразу после вызова, поэтому копируем
+			_deferred.Enqueue(new AnalyticsEventPayload(payload.id)
+			{
+				parameters = payload.parameters != null
+					? new Dictionary<string, object>(payload.parameters)
+					: null
+			});
+		}
+
+		private void SendInternal(AnalyticsEventPayload payload)
+		{
 			foreach (var integration in _integrations)
 			{
 				if (_isValidationEnabled && !integration.IsValid(in payload, out var error))
@@ -94,8 +121,6 @@ namespace Analytics
 
 				integration.SendEvent(in payload);
 			}
-
-			AnalyticsDebug.Log($"Sent event: {payload}\n{_cachedIntegrationsDebugMessage}");
 		}
 
 		private async UniTask InitializeIntegrationAsync(IAnalyticsIntegration integration, CancellationToken cancellationToken)

--- a/Infrastructure/Notifications/NotificationsManagement.cs
+++ b/Infrastructure/Notifications/NotificationsManagement.cs
@@ -133,10 +133,10 @@ namespace Notifications
 			NotificationsDebug.Log(SCHEDULED_LOG_MESSAGE_FORMAT.Format(request));
 
 			// Планирование на платформе дорогое, поэтому пачку уведомлений раскладываем по кадрам
-			_deferred.Handle(request);
+			_deferred.Handle(in request);
 		}
 
-		private void ScheduleInternal(NotificationRequest request)
+		private void ScheduleInternal(in NotificationRequest request)
 		{
 			if (!_platform.Schedule(in request))
 				NotificationsDebug.LogError(FAILED_LOG_MESSAGE_FORMAT.Format(request));

--- a/Infrastructure/Notifications/NotificationsManagement.cs
+++ b/Infrastructure/Notifications/NotificationsManagement.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Fusumity.Reactive;
 using Sapientia.Collections;
 using Sapientia.Extensions;
@@ -50,12 +49,17 @@ namespace Notifications
 				RemoveAll();
 			}
 
-			_schedulerToOverrider = ReflectionUtility.GetAllTypes<ISchedulerOverrider>(false)
-				.Where(type => typeof(IPlatformNotification<>).MakeGenericType(PlatformType).IsAssignableFrom(type))
-				.ToDictionary(
-					type => type,
-					type => type.GetInterface(typeof(ISchedulerOverrider<>).Name)!.GetGenericArguments().First()
-				);
+			_schedulerToOverrider = new Dictionary<Type, Type>();
+			var platformInterface = typeof(IPlatformNotification<>).MakeGenericType(PlatformType);
+			foreach (var overriderType in ReflectionUtility.GetAllTypes<ISchedulerOverrider>(false))
+			{
+				if (!platformInterface.IsAssignableFrom(overriderType))
+					continue;
+
+				var schedulerType = overriderType.GetInterface(typeof(ISchedulerOverrider<>).Name)!
+					.GetGenericArguments()[0];
+				_schedulerToOverrider[schedulerType] = overriderType;
+			}
 
 			_deferred = new DeferredQueue<NotificationRequest>(ScheduleInternal);
 
@@ -88,7 +92,9 @@ namespace Notifications
 		internal bool Register<T>(T scheduler)
 			where T : NotificationScheduler
 		{
-			var type = typeof(T);
+			// Вызов приходит из конструктора базового класса, где this типизирован как
+			// NotificationScheduler, поэтому typeof(T) здесь бесполезен — берем тип с инстанса
+			var type = scheduler.GetType();
 
 			if (_settings.disableSchedulers.Contains(type.FullName))
 				return false;
@@ -105,7 +111,7 @@ namespace Notifications
 		}
 
 		internal bool Unregister<T>(T scheduler) where T : NotificationScheduler
-			=> _registeredSchedulers.Remove(scheduler);
+			=> _registeredSchedulers != null && _registeredSchedulers.Remove(scheduler);
 
 		internal void Schedule(ref NotificationRequest request)
 		{

--- a/Infrastructure/Notifications/NotificationsManagement.cs
+++ b/Infrastructure/Notifications/NotificationsManagement.cs
@@ -13,12 +13,15 @@ namespace Notifications
 	{
 		private const int DEFAULT_DELAY_MIN = 5;
 		private const string SCHEDULED_LOG_MESSAGE_FORMAT = "Scheduled notification: {0}";
+		private const string FAILED_LOG_MESSAGE_FORMAT = "Failed to schedule notification: {0}";
 		private const string INVALID_ARGS_BY_TIME_LOGS_MESSAGE = "RemainingTime or deliveryTime can't be null at the same time";
 
 		private readonly INotificationPlatform _platform;
 		private readonly NotificationsSettings _settings;
 
 		private List<NotificationScheduler> _registeredSchedulers;
+
+		private DeferredQueue<NotificationRequest> _deferred;
 
 		//Пока соотношение 1 к 1, но пока не придумал кейсов когда нужно больше одного overrider'а
 		private Dictionary<Type, Type> _schedulerToOverrider;
@@ -54,6 +57,8 @@ namespace Notifications
 					type => type.GetInterface(typeof(ISchedulerOverrider<>).Name)!.GetGenericArguments().First()
 				);
 
+			_deferred = new DeferredQueue<NotificationRequest>(ScheduleInternal);
+
 			UnityLifecycle.ApplicationFocusEvent += OnApplicationFocus;
 		}
 
@@ -63,6 +68,8 @@ namespace Notifications
 				return;
 
 			_schedulerToOverrider = null;
+
+			DisposeUtility.DisposeAndSetNull(ref _deferred);
 
 			_platform.NotificationReceived -= OnNotificationReceived;
 
@@ -122,8 +129,17 @@ namespace Notifications
 			NotificationsDebug.ApplySettings(ref request, now);
 #endif
 
-			if (_platform.Schedule(in request))
-				NotificationsDebug.Log(SCHEDULED_LOG_MESSAGE_FORMAT.Format(request));
+			// Логируем до откладывания, пока в стеке виден инициатор
+			NotificationsDebug.Log(SCHEDULED_LOG_MESSAGE_FORMAT.Format(request));
+
+			// Планирование на платформе дорогое, поэтому пачку уведомлений раскладываем по кадрам
+			_deferred.Handle(request);
+		}
+
+		private void ScheduleInternal(NotificationRequest request)
+		{
+			if (!_platform.Schedule(in request))
+				NotificationsDebug.LogError(FAILED_LOG_MESSAGE_FORMAT.Format(request));
 		}
 
 		internal void Cancel(string id) => _platform?.Cancel(id);

--- a/Infrastructure/Notifications/NotificationsManagement.cs
+++ b/Infrastructure/Notifications/NotificationsManagement.cs
@@ -10,7 +10,6 @@ namespace Notifications
 {
 	public class NotificationsManagement : IDisposable
 	{
-		private const int DEFAULT_DELAY_MIN = 5;
 		private const string SCHEDULED_LOG_MESSAGE_FORMAT = "Scheduled notification: {0}";
 		private const string FAILED_LOG_MESSAGE_FORMAT = "Failed to schedule notification: {0}";
 		private const string INVALID_ARGS_BY_TIME_LOGS_MESSAGE = "RemainingTime or deliveryTime can't be null at the same time";

--- a/Infrastructure/Notifications/Platforms/Android/AndroidNotificationPlatform.cs
+++ b/Infrastructure/Notifications/Platforms/Android/AndroidNotificationPlatform.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Content;
 using Localization;
 using Notifications.Android.Config;
@@ -40,20 +39,38 @@ namespace Notifications.Android
 
 		public AndroidNotificationPlatform()
 		{
+			// Явно, а не побочным эффектом обращения к UserPermissionToPost/RegisterNotificationChannel:
+			// без инициализации mUnityNotificationManager пуст и восстановление _ids молча пропускается
+			if (!AndroidNotificationCenter.Initialize())
+			{
+				NotificationsDebug.LogError("[Android] Failed to initialize AndroidNotificationCenter");
+				return;
+			}
+
 			_ids = new();
+
 			InitializeChannels();
-			var userPermission = AndroidNotificationCenter.UserPermissionToPost;
-			foreach (var (systemId, notif) in EnumerateScheduledNotificationsInternal())
-				TryRestoreId(notif.id, systemId);
+
+			try
+			{
+				foreach (var (systemId, notif) in EnumerateScheduledNotificationsInternal())
+					TryRestoreId(notif.id, systemId);
+			}
+			catch (Exception e)
+			{
+				// Читаем приватные поля плагина через рефлексию — обновление пакета может их поменять
+				NotificationsDebug.LogError($"[Android] Failed to restore scheduled notification ids: {e}");
+			}
 
 			AndroidNotificationCenter.OnNotificationReceived += OnNotificationReceived;
 
-			NotificationsDebug.Log($"[Android] User Permission: {userPermission}");
+			NotificationsDebug.Log($"[Android] User Permission: {AndroidNotificationCenter.UserPermissionToPost}");
 		}
 
 		public void Dispose()
 		{
 			AndroidNotificationCenter.OnNotificationReceived -= OnNotificationReceived;
+
 			_ids?.Dispose();
 			_ids = null;
 		}
@@ -113,9 +130,17 @@ namespace Notifications.Android
 			}
 
 			if (_ids.TryGetValue(request.id, out var androidId))
+			{
 				AndroidNotificationCenter.SendNotificationWithExplicitID(notification, channel, androidId);
+			}
 			else
-				_ids[request.id] = AndroidNotificationCenter.SendNotification(notification, channel);
+			{
+				var newId = AndroidNotificationCenter.SendNotification(notification, channel);
+				if (newId < 0)
+					return false;
+
+				_ids[request.id] = newId;
+			}
 
 			return true;
 		}
@@ -127,8 +152,8 @@ namespace Notifications.Android
 		/// Каждый запрос поднимает системную GrantPermissionsActivity, а это pause/resume приложения.
 		/// Если планирование завязано на потерю фокуса, получается бесконечный цикл, в котором система
 		/// в итоге сносит активити игры (rapidActivityLaunch), и Unity убивает процесс в onDestroy.
-		/// Отказ при этом может приходить мгновенно и без диалога — например под Enhanced Confirmation Mode
-		/// (Android 16) для сборок, установленных не из стора
+		/// Отказ при этом может приходить мгновенно и без диалога — например после двух отказов на Android 11+
+		/// (разрешение переходит в «Don't ask again») или при device policy с авто-отказом
 		/// </remarks>
 		private static void TryRequestUserPermission()
 		{
@@ -181,8 +206,8 @@ namespace Notifications.Android
 
 		public IEnumerable<NotificationRequest> EnumerateScheduledNotifications()
 		{
-			return EnumerateScheduledNotificationsInternal()
-				.Select(x => x.notif);
+			foreach (var (_, notif) in EnumerateScheduledNotificationsInternal())
+				yield return notif;
 		}
 
 		private IEnumerable<(int systemId, NotificationRequest notif)> EnumerateScheduledNotificationsInternal()

--- a/Infrastructure/Notifications/Platforms/Android/AndroidNotificationPlatform.cs
+++ b/Infrastructure/Notifications/Platforms/Android/AndroidNotificationPlatform.cs
@@ -32,6 +32,8 @@ namespace Notifications.Android
 		private const string EXTRA_FIRE_TIME = "fireTime";
 		private const string EXTRA_REPEAT_INTERVAL = "repeatInterval";
 
+		private static bool _permissionRequested;
+
 		private BidirectionalMap<string, int> _ids;
 
 		public event Action<string, string> NotificationReceived;
@@ -118,8 +120,23 @@ namespace Notifications.Android
 			return true;
 		}
 
+		/// <summary>
+		/// Запрашивает разрешение не более одного раза за сессию
+		/// </summary>
+		/// <remarks>
+		/// Каждый запрос поднимает системную GrantPermissionsActivity, а это pause/resume приложения.
+		/// Если планирование завязано на потерю фокуса, получается бесконечный цикл, в котором система
+		/// в итоге сносит активити игры (rapidActivityLaunch), и Unity убивает процесс в onDestroy.
+		/// Отказ при этом может приходить мгновенно и без диалога — например под Enhanced Confirmation Mode
+		/// (Android 16) для сборок, установленных не из стора
+		/// </remarks>
 		private static void TryRequestUserPermission()
 		{
+			if (_permissionRequested)
+				return;
+
+			_permissionRequested = true;
+
 			if (AndroidNotificationCenter.UserPermissionToPost == PermissionStatus.Allowed)
 				return;
 

--- a/Infrastructure/SharedLogic/Management/CommandBuffer.cs
+++ b/Infrastructure/SharedLogic/Management/CommandBuffer.cs
@@ -82,6 +82,15 @@ namespace SharedLogic
 			_typeToBuffer[entry.type].OnExecute(root, entry.index);
 		}
 
+		/// <summary>
+		/// Отправить первую команду в очереди в раннер, не теряя её тип
+		/// </summary>
+		public bool Run(ICommandRunner runner)
+		{
+			var entry = _queue.Peek();
+			return _typeToBuffer[entry.type].Run(runner, entry.index);
+		}
+
 		public bool Validate(ISharedRoot root, out Exception exception)
 		{
 			var entry = _queue.Peek();
@@ -167,6 +176,12 @@ namespace SharedLogic
 			center.Submit(in command);
 		}
 
+		public bool Run(ICommandRunner runner, int index)
+		{
+			ref var command = ref _buffer[index];
+			return runner.Execute(in command);
+		}
+
 		public ICommand Get(int index)
 		{
 			return _buffer[index];
@@ -189,6 +204,7 @@ namespace SharedLogic
 		public void OnExecute(ISharedRoot root, int index);
 		public bool Validate(ISharedRoot root, int index, out Exception exception);
 		public void Send(ICommandCenter center, int index);
+		public bool Run(ICommandRunner runner, int index);
 		public ICommand Get(int index);
 		public void AddCommandToList(int index, SimpleList<ICommand> list);
 	}

--- a/Infrastructure/SharedLogic/Management/DeferredCommandRunner.cs
+++ b/Infrastructure/SharedLogic/Management/DeferredCommandRunner.cs
@@ -1,0 +1,146 @@
+using System;
+using Fusumity.Reactive;
+
+namespace SharedLogic
+{
+	/// <summary>
+	/// После возвращения приложения из фона держит лимит команд на кадр: всё сверх лимита уходит
+	/// в очередь и разбирается порциями в следующих кадрах, чтобы не грузить первый кадр (борьба с ANR)
+	/// </summary>
+	public class DeferredCommandRunner : CommandRunnerDecorator, IDisposable
+	{
+		private CommandBuffer _buffer;
+
+		private readonly DeferredGate _gate;
+		private readonly bool _ownsGate;
+
+		private bool _executing;
+
+		public override bool IsEmpty { get => _buffer.IsEmpty && base.IsEmpty; }
+
+		/// <inheritdoc cref="DeferredGate"/>
+		public DeferredGate Gate { get => _gate; }
+
+		public DeferredCommandRunner(ICommandRunner runner, DeferredGate gate = null) : base(runner)
+		{
+			_buffer = new CommandBuffer();
+
+			_ownsGate = gate == null;
+			_gate = gate ?? new DeferredGate();
+			_gate.Closed += Flush;
+
+			UnityLifecycle.UpdateEvent.Subscribe(HandleUpdate);
+		}
+
+		public void Dispose()
+		{
+			UnityLifecycle.UpdateEvent.UnSubscribe(HandleUpdate);
+
+			_gate.Closed -= Flush;
+
+			Flush();
+
+			if (_ownsGate)
+				_gate.Dispose();
+
+			_buffer.Dispose();
+			_buffer = null;
+		}
+
+		/// <summary>
+		/// Немедленно исполнить все отложенные команды и закрыть окно
+		/// </summary>
+		public void Flush()
+		{
+			_gate.Close();
+
+			if (_buffer.IsEmpty)
+				return;
+
+			Drain(false);
+		}
+
+		/// <inheritdoc/>
+		public override bool Execute<T>(in T command)
+		{
+			// Команда во время исполнения может породить новые — они идут мимо очереди,
+			// их порядок держит буфер ClientCommandRunner
+			if (_executing)
+				return base.Execute(in command);
+
+			// Порядок команд важен: пока очередь не разобрана, новые уходят в её конец
+			if (_buffer.IsEmpty && !_gate.IsOpen)
+				return Run(in command);
+
+			// Команду, которая требует немедленной реакции, не откладываем, но сохраняем порядок
+			if (command.Priority == CommandPriority.Immediately)
+			{
+				Flush();
+				return Run(in command);
+			}
+
+			if (_buffer.IsEmpty && _gate.TryTakeBudget())
+				return Run(in command);
+
+			_buffer.Enqueue(in command);
+			return true;
+		}
+
+		private bool Run<T>(in T command)
+			where T : struct, ICommand
+		{
+			_executing = true;
+
+			try
+			{
+				return base.Execute(in command);
+			}
+			finally
+			{
+				_executing = false;
+			}
+		}
+
+		private void HandleUpdate()
+		{
+			if (_buffer.IsEmpty)
+				return;
+
+			if (!_gate.IsHoldElapsed)
+				return;
+
+			Drain(true);
+		}
+
+		private void Drain(bool budgeted)
+		{
+			_executing = true;
+
+			try
+			{
+				while (!_buffer.IsEmpty && (!budgeted || _gate.TryTakeBudget()))
+				{
+					try
+					{
+						_buffer.Run(this);
+					}
+					catch (Exception exception)
+					{
+						SLDebug.LogException(exception);
+					}
+					finally
+					{
+						_buffer.Dequeue();
+					}
+				}
+			}
+			finally
+			{
+				_executing = false;
+
+				if (_buffer.IsEmpty)
+					_buffer.Clear();
+			}
+		}
+	}
+}

--- a/Infrastructure/SharedLogic/Management/DeferredCommandRunner.cs.meta
+++ b/Infrastructure/SharedLogic/Management/DeferredCommandRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec39aded1d5534097995e6601dfadd36

--- a/Infrastructure/SharedLogic/Management/SharedLogic.Client.asmdef
+++ b/Infrastructure/SharedLogic/Management/SharedLogic.Client.asmdef
@@ -1,4 +1,4 @@
 {
   "name": "SharedLogic.Client",
-  "references":[ "GUID:343deaaf83e0cee4ca978e7df0b80d21", "GUID:2bafac87e7f4b9b418d9448d219b01ab", "GUID:bd10b8cc39d09ac4e9c31728752096c0", "GUID:7f5737a12b714b95a6ba6834be85bff6", "GUID:7f24a995f30d4bdd9bb11cab7b795632" ]
+  "references":[ "GUID:343deaaf83e0cee4ca978e7df0b80d21", "GUID:2bafac87e7f4b9b418d9448d219b01ab", "GUID:bd10b8cc39d09ac4e9c31728752096c0", "GUID:7f5737a12b714b95a6ba6834be85bff6", "GUID:7f24a995f30d4bdd9bb11cab7b795632", "GUID:fab36cbdbe761a64b85aac0ec85e5c7c" ]
 }

--- a/Reactive/DeferredGate.cs
+++ b/Reactive/DeferredGate.cs
@@ -1,0 +1,122 @@
+using System;
+using UnityEngine;
+
+namespace Fusumity.Reactive
+{
+	/// <summary>
+	/// Окно после возвращения приложения из фона: сначала задержка, потом лимит на кадр.
+	/// Нужно, чтобы накопившаяся за время в фоне работа не легла в один кадр (борьба с ANR)
+	/// </summary>
+	public class DeferredGate : IDisposable
+	{
+		private const float DEFAULT_DELAY = 0.5f;
+		private const float DEFAULT_WINDOW_TIME = 5f;
+		private const int DEFAULT_PER_FRAME = 4;
+
+		/// <summary>
+		/// Задержка перед тем как начать разбирать накопленное, считается от возвращения из фона (в секундах)
+		/// </summary>
+		public float delay;
+
+		/// <summary>
+		/// Сколько после возвращения из фона действует лимит (в секундах)
+		/// </summary>
+		public float windowTime;
+
+		/// <summary>
+		/// Сколько элементов пропускаем за кадр
+		/// </summary>
+		public int perFrame;
+
+		private float _openTime;
+		private float _closeTime;
+
+		private int _frameNumber;
+		private int _passedInFrame;
+
+		private bool _closing;
+
+		/// <summary>
+		/// Окно закрылось — накопленное нужно разобрать немедленно
+		/// </summary>
+		public event Action Closed;
+
+		/// <summary>
+		/// Лимит сейчас действует
+		/// </summary>
+		public bool IsOpen { get => Time.realtimeSinceStartup < _closeTime; }
+
+		/// <summary>
+		/// Задержка после возвращения из фона уже прошла
+		/// </summary>
+		public bool IsHoldElapsed { get => Time.realtimeSinceStartup - _openTime >= delay; }
+
+		public DeferredGate(float delay = DEFAULT_DELAY, float windowTime = DEFAULT_WINDOW_TIME, int perFrame = DEFAULT_PER_FRAME)
+		{
+			this.delay = delay;
+			this.windowTime = windowTime;
+			this.perFrame = perFrame;
+
+			UnityLifecycle.ApplicationResumeEvent += Open;
+
+			// Уходим в фон: обновлений больше не будет, поэтому просим разобрать накопленное сразу.
+			// Потеря фокуса приходит раньше паузы, так что хватает её одной
+			UnityLifecycle.ApplicationUnfocusEvent += Close;
+			UnityLifecycle.ApplicationShutdown += Close;
+		}
+
+		public void Dispose()
+		{
+			UnityLifecycle.ApplicationResumeEvent -= Open;
+
+			UnityLifecycle.ApplicationUnfocusEvent -= Close;
+			UnityLifecycle.ApplicationShutdown -= Close;
+
+			Closed = null;
+		}
+
+		public void Open()
+		{
+			_openTime = Time.realtimeSinceStartup;
+			_closeTime = _openTime + windowTime;
+		}
+
+		public void Close()
+		{
+			// Подписчик в ответ на закрытие сливает накопленное и может сам позвать Close
+			if (_closing)
+				return;
+
+			_closing = true;
+
+			try
+			{
+				_closeTime = 0f;
+				Closed?.Invoke();
+			}
+			finally
+			{
+				_closing = false;
+			}
+		}
+
+		/// <summary>
+		/// Занять место в бюджете кадра
+		/// </summary>
+		public bool TryTakeBudget()
+		{
+			var frame = Time.frameCount;
+			if (_frameNumber != frame)
+			{
+				_frameNumber = frame;
+				_passedInFrame = 0;
+			}
+
+			if (_passedInFrame >= perFrame)
+				return false;
+
+			_passedInFrame++;
+			return true;
+		}
+	}
+}

--- a/Reactive/DeferredGate.cs.meta
+++ b/Reactive/DeferredGate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53995233511cd49fa86618d3cf6ae9cd

--- a/Reactive/DeferredQueue.cs
+++ b/Reactive/DeferredQueue.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Fusumity.Reactive
+{
+	/// <summary>
+	/// Очередь, которая после возвращения приложения из фона пропускает не больше нескольких элементов
+	/// за кадр, а остальное разбирает в следующих кадрах (борьба с ANR)
+	/// </summary>
+	public class DeferredQueue<T> : IDisposable
+	{
+		private readonly Action<T> _handler;
+		private readonly Queue<T> _queue;
+
+		private readonly DeferredGate _gate;
+		private readonly bool _ownsGate;
+
+		private bool _handling;
+
+		public bool IsEmpty { get => _queue.Count == 0; }
+
+		/// <inheritdoc cref="DeferredGate"/>
+		public DeferredGate Gate { get => _gate; }
+
+		public DeferredQueue(Action<T> handler, DeferredGate gate = null)
+		{
+			_handler = handler;
+			_queue = new Queue<T>();
+
+			_ownsGate = gate == null;
+			_gate = gate ?? new DeferredGate();
+			_gate.Closed += Flush;
+
+			UnityLifecycle.UpdateEvent.Subscribe(HandleUpdate);
+		}
+
+		public void Dispose()
+		{
+			UnityLifecycle.UpdateEvent.UnSubscribe(HandleUpdate);
+
+			_gate.Closed -= Flush;
+
+			Flush();
+
+			if (_ownsGate)
+				_gate.Dispose();
+		}
+
+		/// <summary>
+		/// Можно ли обработать элемент прямо сейчас, не откладывая.
+		/// Нужно тем, кому перед откладыванием требуется скопировать данные
+		/// </summary>
+		public bool CanHandleNow()
+		{
+			// Обработчик мог породить новый элемент — его пропускаем, чтобы не ломать порядок
+			if (_handling)
+				return true;
+
+			if (!IsEmpty)
+				return false;
+
+			return !_gate.IsOpen || _gate.TryTakeBudget();
+		}
+
+		/// <summary>
+		/// Обработать элемент сейчас или отложить, если бюджет кадра исчерпан
+		/// </summary>
+		public void Handle(T item)
+		{
+			if (CanHandleNow())
+			{
+				Invoke(item);
+				return;
+			}
+
+			_queue.Enqueue(item);
+		}
+
+		public void Enqueue(T item) => _queue.Enqueue(item);
+
+		/// <summary>
+		/// Немедленно обработать всё отложенное и закрыть окно
+		/// </summary>
+		public void Flush()
+		{
+			_gate.Close();
+
+			while (!IsEmpty)
+				Invoke(_queue.Dequeue());
+		}
+
+		private void HandleUpdate()
+		{
+			if (IsEmpty)
+				return;
+
+			if (!_gate.IsHoldElapsed)
+				return;
+
+			while (!IsEmpty && _gate.TryTakeBudget())
+				Invoke(_queue.Dequeue());
+		}
+
+		private void Invoke(T item)
+		{
+			_handling = true;
+
+			try
+			{
+				_handler.Invoke(item);
+			}
+			catch (Exception exception)
+			{
+				Debug.LogException(exception);
+			}
+			finally
+			{
+				_handling = false;
+			}
+		}
+	}
+}

--- a/Reactive/DeferredQueue.cs
+++ b/Reactive/DeferredQueue.cs
@@ -1,32 +1,40 @@
 using System;
-using System.Collections.Generic;
+using Sapientia.Collections;
 using UnityEngine;
 
 namespace Fusumity.Reactive
 {
+	public delegate void DeferredHandler<T>(in T item);
+
 	/// <summary>
 	/// Очередь, которая после возвращения приложения из фона пропускает не больше нескольких элементов
 	/// за кадр, а остальное разбирает в следующих кадрах (борьба с ANR)
 	/// </summary>
 	public class DeferredQueue<T> : IDisposable
 	{
-		private readonly Action<T> _handler;
-		private readonly Queue<T> _queue;
+		private readonly DeferredHandler<T> _handler;
+
+		/// <remarks>
+		/// Список вместо очереди, чтобы отдавать элемент обработчику по ссылке, без копии структуры.
+		/// Голова двигается индексом, массив чистится когда очередь разобрана
+		/// </remarks>
+		private readonly SimpleList<T> _items;
+		private int _head;
 
 		private readonly DeferredGate _gate;
 		private readonly bool _ownsGate;
 
 		private bool _handling;
 
-		public bool IsEmpty { get => _queue.Count == 0; }
+		public bool IsEmpty { get => _head >= _items.Count; }
 
 		/// <inheritdoc cref="DeferredGate"/>
 		public DeferredGate Gate { get => _gate; }
 
-		public DeferredQueue(Action<T> handler, DeferredGate gate = null)
+		public DeferredQueue(DeferredHandler<T> handler, DeferredGate gate = null)
 		{
 			_handler = handler;
-			_queue = new Queue<T>();
+			_items = new SimpleList<T>();
 
 			_ownsGate = gate == null;
 			_gate = gate ?? new DeferredGate();
@@ -45,6 +53,8 @@ namespace Fusumity.Reactive
 
 			if (_ownsGate)
 				_gate.Dispose();
+
+			_items.Dispose();
 		}
 
 		/// <summary>
@@ -66,18 +76,22 @@ namespace Fusumity.Reactive
 		/// <summary>
 		/// Обработать элемент сейчас или отложить, если бюджет кадра исчерпан
 		/// </summary>
-		public void Handle(T item)
+		public void Handle(in T item)
 		{
 			if (CanHandleNow())
 			{
-				Invoke(item);
+				Invoke(in item);
 				return;
 			}
 
-			_queue.Enqueue(item);
+			_items.Add(in item);
 		}
 
-		public void Enqueue(T item) => _queue.Enqueue(item);
+		/// <remarks>
+		/// ⚠️ Обработчик получает элемент по ссылке на внутренний массив, поэтому пополнять очередь
+		/// во время разбора нельзя — <see cref="CanHandleNow"/> это гарантирует
+		/// </remarks>
+		public void Enqueue(in T item) => _items.Add(in item);
 
 		/// <summary>
 		/// Немедленно обработать всё отложенное и закрыть окно
@@ -87,7 +101,7 @@ namespace Fusumity.Reactive
 			_gate.Close();
 
 			while (!IsEmpty)
-				Invoke(_queue.Dequeue());
+				InvokeNext();
 		}
 
 		private void HandleUpdate()
@@ -99,16 +113,28 @@ namespace Fusumity.Reactive
 				return;
 
 			while (!IsEmpty && _gate.TryTakeBudget())
-				Invoke(_queue.Dequeue());
+				InvokeNext();
 		}
 
-		private void Invoke(T item)
+		private void InvokeNext()
+		{
+			Invoke(in _items[_head]);
+			_head++;
+
+			if (!IsEmpty)
+				return;
+
+			_items.ClearPartial();
+			_head = 0;
+		}
+
+		private void Invoke(in T item)
 		{
 			_handling = true;
 
 			try
 			{
-				_handler.Invoke(item);
+				_handler.Invoke(in item);
 			}
 			catch (Exception exception)
 			{

--- a/Reactive/DeferredQueue.cs.meta
+++ b/Reactive/DeferredQueue.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ab73da269f9ac45eaaff883a7eb70cdf


### PR DESCRIPTION
- frame budget window opened on returning from background
- shared by command runner, analytics and notifications [*] Updated "Command runner"
- commands over the frame budget are queued and run in the next frames
- nested and Immediately commands bypass the queue
- queue is flushed on unfocus and shutdown [*] Updated "Analytics"
- sending to integrations is spread over frames
- event parameters are copied on defer, source dictionary comes from a pool [*] Updated "Notifications"
- platform scheduling is spread over frames
- schedule log moved to the call site, platform failure is logged now